### PR TITLE
feat: enable forward-compatible enums

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -63,7 +63,7 @@ python:
   flattenGlobalSecurity: true
   flattenRequests: true
   flatteningOrder: parameters-first
-  forwardCompatibleEnumsByDefault: false
+  forwardCompatibleEnumsByDefault: true
   forwardCompatibleUnionsByDefault: "false"
   homepage: https://moov.io/
   imports:


### PR DESCRIPTION
## Description

Sets `forwardCompatibleEnumsByDefault: true` in `.speakeasy/gen.yaml` so this SDK treats unrecognized enum values in API responses as open/unknown instead of raising a validation error. Today, when the API starts returning a new enum value, older pinned SDKs throw an exception on the response with no way for the caller to know whether their request actually succeeded.

Per [Speakeasy's SDK resilience docs](https://www.speakeasy.com/docs/sdks/manage/forward-compatibility/#configuring-sdk-resilience).

Config-only change — the next scheduled/triggered SDK generation run will regenerate against this setting.